### PR TITLE
feat: copy Solace CSS styles and fonts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;600;700&family=Space+Mono:wght@700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --solace-green: #3dba91;
+  --solace-bright-green: #00c895;
+  --solace-blue: #093B5F;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 import ErrorBoundary from "../components/ErrorBoundary";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   // Update to something about Advocate API
@@ -18,7 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className="font-sans">
         <ErrorBoundary>{children}</ErrorBoundary>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export const dynamic = 'force-dynamic';
 export default async function Home() {
   return (
     <main className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-8">Solace Advocates</h1>
+      <h1 className="text-3xl font-bold mb-8 text-solace-green">Solace Advocates</h1>
       <SearchClientWithStore />
     </main>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,17 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        solace: {
+          green: 'var(--solace-green)',
+          brightGreen: 'var(--solace-bright-green)',
+          blue: 'var(--solace-blue)',
+        },
+      },
+      fontFamily: {
+        sans: ['Figtree', 'sans-serif'],
+        mono: ['Space Mono', 'monospace'],
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":


### PR DESCRIPTION
## Summary
- Researched and integrated Solace Technologies' brand colors and fonts
- Added CSS custom properties for Solace green, bright green, and blue
- Integrated Figtree (sans-serif) and Space Mono (monospace) fonts via Google Fonts
- Updated Tailwind config to use Solace colors and fonts
- Applied Solace green color to the main heading for brand consistency